### PR TITLE
pass CLICOLOR_FORCE=1 environment variable to glow

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,7 @@ function M:peek()
 				tostring(self.area.w),
 				tostring(self.file.url),
 			})
+			:env("CLICOLOR_FORCE", "1")
 			:stdout(Command.PIPED)
 			:stderr(Command.PIPED)
 			:spawn()


### PR DESCRIPTION
without `CLICOLOR_FORCE`:
![pic](https://github.com/user-attachments/assets/216112b6-2933-4181-a221-43e9e3de6c36)

with `CLICOLOR_FORCE`:
![pic](https://github.com/user-attachments/assets/e9461162-86f0-4f01-b646-607cda232335)

related upstream issue: https://github.com/charmbracelet/glow/issues/440#issuecomment-2206744055