### PR TITLE
Use glow auto style instead of dark

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,7 +7,7 @@ function M:peek(job)
 	local child = Command("glow")
 		:args({
 			"--style",
-			"dark",
+			"auto",
 			"--width",
 			tostring(preview_width),  -- Use fixed width instead of job.area.w
 			tostring(job.file.url),


### PR DESCRIPTION
This allow to follow the system theme, instead of forcing the dark variant.